### PR TITLE
chore: django-redis 설치 및 설정

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,5 +29,12 @@ services:
     image: redis:7
     ports:
         - "6379:6379"
+  redis_cache:
+    image: redis:7
+    ports:
+        - "6380:6380"
+    volumes:
+      - redis_data:/data
 volumes:
   static_volume:
+  redis_data:

--- a/hackathon/settings/prod.py
+++ b/hackathon/settings/prod.py
@@ -27,3 +27,13 @@ CHANNEL_LAYERS = {
     },
 }
 
+CACHES = {
+    "default": {
+        "BACKEND": "django_redis.cache.RedisCache",
+        "LOCATION": "redis://redis_cache:6380/1",
+        "OPTIONS": {
+            "CLIENT_CLASS": "django_redis.client.DefaultClient",
+        }
+    }
+}
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,7 @@ dj-rest-auth==4.0.1
 Django==4.2.3
 django-allauth==0.54.0
 django-cors-headers==4.2.0
+django-redis==5.3.0
 djangorestframework==3.14.0
 djangorestframework-simplejwt==5.2.2
 drf-yasg==1.21.6


### PR DESCRIPTION
### 작업한 내용
- 택시기사 위치 저장 및 geo 활용을 위해 서버에 django-redis 설치 및 설정
- settings.py의 설정을 통해서 아래와 같은 장점을 얻음
```
django-redis를 사용하면 Django의 캐싱 인터페이스를 통해 일반적인 캐시 작업을 수행할 수 있으며,
필요한 경우 저수준의 redis-py 클라이언트에도 접근할 수 있다는 유연성을 제공합니다.
이로 인해 코드 관리가 더 쉬워지며, 나중에 캐시 백엔드를 변경해야 할 경우에도 더 쉽게 변경할 수 있습니다.
```
- 즉, redis_con = Redis(host="localhost", port=6379)를 쓰지 않고 django_redis.~~ 로 사용할 수 있게 됩니다.
- prod 환경에서의 redis_cache의 port는 6380입니다.
### 논의할 내용
- 노션 코드에 쓰신 Import Redis가 더 편하다면 말씀해주세용
