### PR TITLE
feat: call 성공 api 추가

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,6 +26,8 @@ jobs:
           echo "S3_ACCESS_KEY=${{ secrets.S3_ACCESS_KEY }}" >> .env
           echo "S3_SECRET_KEY=${{ secrets.S3_SECRET_KEY }}" >> .env
           echo "HASH_SALT=${{ secrets.HASH_SALT }}" >> .env
+          echo "REDIS_CACHE_HOST=${{ secrets.REDIS_CACHE_HOST }}" >> .env
+          echo "REDIS_CACHE_PORT=${{ secrets.REDIS_CACHE_PORT }}" >> .env
 
       - name: Set up and build Docker Compose
         run: |

--- a/call/serializers/__init__.py
+++ b/call/serializers/__init__.py
@@ -1,1 +1,2 @@
 from .call_serializer import *
+from .call_success_serializer import *

--- a/call/serializers/call_success_serializer.py
+++ b/call/serializers/call_success_serializer.py
@@ -1,0 +1,16 @@
+from rest_framework import serializers
+from call.models import Assign
+from driver.models import CustomDriver
+
+class CallSuccessDriverInfoSerializer(serializers.ModelSerializer):
+    
+    class Meta:
+        model = CustomDriver
+        fields = ("id" ,"name", "taxi_num", "car_type",)
+
+class CallSuccessGetSerializer(serializers.ModelSerializer):
+    driver_id = CallSuccessDriverInfoSerializer()
+
+    class Meta:
+        model = Assign
+        fields = ("id", "driver_id",)

--- a/call/services/__init__.py
+++ b/call/services/__init__.py
@@ -1,1 +1,2 @@
 from .call_main_service import *
+from .call_success_service import *

--- a/call/services/call_main_service.py
+++ b/call/services/call_main_service.py
@@ -22,4 +22,7 @@ def post_main(post_main_data, hashed_qr_id: str):
     post_main_serializer = CallMainPostSerializer(data=post_main_data)
     post_main_serializer.is_valid(raise_exception=True)
     post_main_serializer.save()
-    return post_main_serializer.data
+    result = post_main_serializer.data
+    assign_id = result.get('id')
+    result['hashed_assign_id'] = Hashing.encode(assign_id)
+    return result

--- a/call/services/call_success_service.py
+++ b/call/services/call_success_service.py
@@ -1,0 +1,62 @@
+from call.models import Assign
+from call.serializers import CallSuccessGetSerializer
+from decouple import config
+import urllib, json
+from rest_framework import exceptions
+from redis import Redis
+from utils import Hashing
+
+def get_driver_location(driver_id):
+    redis_con = Redis(host="redis_cache", port=6380)
+    saved_location = redis_con.geopos("driver_location", driver_id)
+    result = (saved_location[0][0], saved_location[0][1])
+    return result
+
+def change_ms_to_m(milliseconds):
+    """
+    밀리세컨즈로 나오는 duration 값을 ~분 ~초로 바꿔주는 로직
+    """
+    seconds = milliseconds // 1000
+    minutes, seconds = divmod(seconds, 60)
+    return f"{minutes}분 {seconds}초"
+
+def calculate_estimated_distance(assign_info):
+    """
+    현재 기사 위치와 qr 장소의 소요시간을 계산해주는 로직
+    """
+    client_id = config('NCP_CLIENT_ID')
+    client_secret = config('NCP_CLIENT_SECRET')
+    
+    start = get_driver_location(assign_info.driver_id.id)
+    goal = (assign_info.qr_id.longitude, assign_info.qr_id.latitude)
+
+    url = f"https://naveropenapi.apigw.ntruss.com/map-direction/v1/driving?start={start[0]},{start[1]}&goal={goal[0]},{goal[1]}&option=trafast"
+    request = urllib.request.Request(url)
+    request.add_header('X-NCP-APIGW-API-KEY-ID', client_id)
+    request.add_header(f'X-NCP-APIGW-API-KEY', client_secret)
+    
+    response = urllib.request.urlopen(request)
+    res = response.getcode()
+    
+    if (res == 200) :
+        response_body = response.read().decode('utf-8')
+        response_body_json = json.loads(response_body)
+        result = response_body_json['route']['trafast'][0]['summary']
+        duration = change_ms_to_m(result['duration'])
+        return duration    
+    else:
+        raise exceptions.ValidationError("시간 계산을 실패하였습니다.")
+
+def get_success_info(hashed_assign_id: str):
+    """
+    기사가 배정된 assign 정보를 불러오는 service
+    """
+    assign_id = Hashing.decode(hashed_assign_id)
+    get_assign_info = Assign.objects.select_related('qr_id', 'driver_id').get(id=assign_id)
+    if get_assign_info.status == 'success':
+        get_assign_serializer = CallSuccessGetSerializer(get_assign_info)
+        result = get_assign_serializer.data
+        result['estimated_time'] = calculate_estimated_distance(get_assign_info)
+        return result
+    else:
+        raise exceptions.ValidationError("잘못된 운행 상태입니다.")

--- a/call/services/call_success_service.py
+++ b/call/services/call_success_service.py
@@ -5,9 +5,13 @@ import urllib, json
 from rest_framework import exceptions
 from redis import Redis
 from utils import Hashing
+from decouple import config
 
 def get_driver_location(driver_id):
-    redis_con = Redis(host="redis_cache", port=6380)
+    redis_host = config('REDIS_CACHE_HOST')
+    redis_port = config('REDIS_CACHE_PORT')
+
+    redis_con = Redis(host=redis_host, port=redis_port)
     saved_location = redis_con.geopos("driver_location", driver_id)
     result = (saved_location[0][0], saved_location[0][1])
     return result

--- a/call/urls.py
+++ b/call/urls.py
@@ -1,9 +1,10 @@
 from django.urls import path
-from call.views import CallMainView
+from call.views import CallMainView, CallSuccessView
 from test.views import liveblog_index
 app_name = 'call'
 
 urlpatterns = [
     path("wstest/<str:post_pk>/", liveblog_index),
     path('main/<str:hashed_qr_id>', CallMainView.as_view()),
+    path('success/<str:hashed_assign_id>', CallSuccessView.as_view()),
 ]

--- a/call/views/__init__.py
+++ b/call/views/__init__.py
@@ -1,1 +1,2 @@
 from .call_main_view import CallMainView
+from .call_success_view import CallSuccessView

--- a/call/views/call_success_view.py
+++ b/call/views/call_success_view.py
@@ -1,0 +1,16 @@
+from rest_framework.response import Response
+from rest_framework import status, exceptions
+from rest_framework.views import APIView
+from call.services import get_success_info
+
+class CallSuccessView(APIView):
+    """
+    택시 호출 성공 후 assign 정보를 보여주는 view
+    """
+    def get(self, request, hashed_assign_id: str):
+        try:
+            response = get_success_info(hashed_assign_id)
+            return Response(response, status=status.HTTP_200_OK)
+        except exceptions.ValidationError as e:
+            return Response({"detail": "잘못된 요청입니다.", "error": e.detail}, status=status.HTTP_400_BAD_REQUEST)
+        

--- a/test/redis_test.py
+++ b/test/redis_test.py
@@ -2,6 +2,7 @@ from rest_framework.views import APIView
 from redis import Redis
 from rest_framework.response import Response
 from rest_framework import status
+from decouple import config
 
 # 위치 저장하기 x:latitude(위도) y: longitude(경도)
 class UpdateDriverLocationView(APIView):
@@ -10,7 +11,10 @@ class UpdateDriverLocationView(APIView):
         driver_id = data.get('id')
         x = data.get('x')
         y = data.get('y')
-        redis_con = Redis(host="redis_cache", port=6380)
+        redis_host = config('REDIS_CACHE_HOST')
+        redis_port = config('REDIS_CACHE_PORT')
+
+        redis_con = Redis(host=redis_host, port=redis_port)
         # 위도, 경도, id 순으로
         try:
             if redis_con.ping():
@@ -40,7 +44,10 @@ class GetNearestDriversView(APIView):
         x = data.get('x')
         y = data.get('y')
 
-        redis_con = Redis(host="redis_cache", port=6380)
+        redis_host = config('REDIS_CACHE_HOST')
+        redis_port = config('REDIS_CACHE_PORT')
+
+        redis_con = Redis(host=redis_host, port=redis_port)
 
         nearest_drivers = redis_con.georadius('driver_location', x, y, 100, 'km', withdist=True, withcoord=True, sort='ASC', count=5)
 

--- a/test/redis_test.py
+++ b/test/redis_test.py
@@ -1,0 +1,49 @@
+from rest_framework.views import APIView
+from redis import Redis
+from rest_framework.response import Response
+from rest_framework import status
+
+# 위치 저장하기 x:latitude(위도) y: longitude(경도)
+class UpdateDriverLocationView(APIView):
+    def post(self, request, *args, **kwargs):
+        data = request.data
+        driver_id = data.get('id')
+        x = data.get('x')
+        y = data.get('y')
+        redis_con = Redis(host="redis_cache", port=6380)
+        # 위도, 경도, id 순으로
+        try:
+            if redis_con.ping():
+                print("Redis connection is active")
+            else:
+                print("Failed to connect to Redis")
+                return Response({'status': 'ERROR', 'message': 'Failed to connect to Redis'}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+        except Exception as e:
+            print(f"An error occurred: {e}")
+            return Response({'status': 'ERROR', 'message': f'An error occurred: {e}'}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+    
+        locations = (x, y, driver_id)
+        redis_con.geoadd("driver_location", locations)
+
+        saved_location = redis_con.geopos("driver_location", driver_id)
+        if saved_location:
+            print(f"Saved location for driver {driver_id}: {saved_location}")
+        else:
+            print(f"Failed to retrieve location for driver {driver_id}")
+
+        return Response({'status': 'OK'}, status=status.HTTP_200_OK)
+
+
+class GetNearestDriversView(APIView):
+    def post(self, request, *args, **kwargs):
+        data = request.data
+        x = data.get('x')
+        y = data.get('y')
+
+        redis_con = Redis(host="redis_cache", port=6380)
+
+        nearest_drivers = redis_con.georadius('driver_location', x, y, 100, 'km', withdist=True, withcoord=True, sort='ASC', count=5)
+
+        formatted_drivers = [{'driver_id': driver[0].decode('utf-8'), 'distance': driver[1], 'latitude': driver[2][0], 'longitude': driver[2][1]} for driver in nearest_drivers]
+
+        return Response({'nearest_drivers': formatted_drivers}, safe=False, status=200)

--- a/test/urls.py
+++ b/test/urls.py
@@ -1,8 +1,10 @@
 from django.urls import path, re_path
-from . import views
+from . import views, redis_test
 
 
 urlpatterns = [
    path('', views.TestView.as_view()),
+   path('update_location/', redis_test.UpdateDriverLocationView.as_view()),
+   path('get_nearest_drivers/', redis_test.GetNearestDriversView.as_view()),
 ]
 


### PR DESCRIPTION
### 작업한 내용
- 콜 성공화면 api 추가
- redis test api를 생성하여서, 예상 도착 소요시간 
- 핸드폰 번호 입력 이후에 assign_id를 해싱한 결과를 반환하도록 수정
-> 이후 이 값을 success/str:hashed_assign_id로 넣어서 url에 assign pk를 숨김
`example response`
```json
{
    "id": 2,
    "driver_id": {
        "id": 2,
        "name": "박근수",
        "taxi_num": "서울12 사1234",
        "car_type": "람보르기니"
    },
    "estimated_time": "3분 3초"
}
```
- redis host와 port를 환경변수로 분리해서 보안성 상승 및 로컬환경과 배포환경의 redis 구성을 분리하였습니다. .env는 노션에 업데이트 했습니다.

### 논의할 내용
- 코드 이상한 곳 있으면 지적 부탁드립니당

### 추후 진행할 내용
- 서버 redis 추가 되는지 확인
- call 취소 api 작성
- redis 예외처리 작성