### PR TITLE
feat: 웹 call 취소 api 추가

### DIFF
--- a/call/services/__init__.py
+++ b/call/services/__init__.py
@@ -1,2 +1,3 @@
 from .call_main_service import *
 from .call_success_service import *
+from .call_cancel_service import *

--- a/call/services/call_cancel_service.py
+++ b/call/services/call_cancel_service.py
@@ -1,0 +1,12 @@
+from call.models import Assign
+from utils.url_hashing import Hashing
+
+def cancel_call(cancel_call_data):
+    """
+    특정 assign의 call status를 cancel로 바꾸는 서비스
+    """
+    assign_id = cancel_call_data.get('assign_id')
+    get_assign_info = Assign.objects.get(id=assign_id)
+    get_assign_info.status = 'cancel'
+    get_assign_info.save(update_fields=['status'])
+    

--- a/call/urls.py
+++ b/call/urls.py
@@ -1,10 +1,11 @@
 from django.urls import path
-from call.views import CallMainView, CallSuccessView
+from call.views import CallMainView, CallSuccessView, CallCancelView
 from test.views import liveblog_index
 app_name = 'call'
 
 urlpatterns = [
     path("wstest/<str:post_pk>/", liveblog_index),
     path('main/<str:hashed_qr_id>', CallMainView.as_view()),
+    path('cancel/', CallCancelView.as_view()),
     path('success/<str:hashed_assign_id>', CallSuccessView.as_view()),
 ]

--- a/call/views/__init__.py
+++ b/call/views/__init__.py
@@ -1,2 +1,3 @@
 from .call_main_view import CallMainView
 from .call_success_view import CallSuccessView
+from .call_cancel_view import CallCancelView

--- a/call/views/call_cancel_view.py
+++ b/call/views/call_cancel_view.py
@@ -1,0 +1,16 @@
+from rest_framework.response import Response
+from rest_framework import status, exceptions
+from rest_framework.views import APIView
+from call.services import cancel_call
+
+
+class CallCancelView(APIView):
+    """
+    웹 택시를 취소하는 View
+    """ 
+    def post(self, request):
+        try:
+            cancel_call(request.data)
+            return Response({"detail": "정상적으로 취소되었습니다."}, status=status.HTTP_200_OK)
+        except exceptions.ValidationError as e:
+             return Response({"detail": "잘못된 요청입니다.", "error": e.detail}, status=status.HTTP_400_BAD_REQUEST)


### PR DESCRIPTION
### 작업한 내용
- 한 assign(배정)의 상태를 cancel로 바꾸는 view 입니다.

### 추후 진행할 내용
- 웹쪽은 얼추 다 끝난 것 같습니다! 이제 프론트와 통신을 해보고, 배정 알고리즘 같이 헤쳐나갑시다