### PR TITLE
refactor: 웹 api 예외처리 추가

### DIFF
--- a/call/services/call_cancel_service.py
+++ b/call/services/call_cancel_service.py
@@ -1,12 +1,15 @@
 from call.models import Assign
-from utils.url_hashing import Hashing
+from rest_framework import exceptions
 
 def cancel_call(cancel_call_data):
     """
     특정 assign의 call status를 cancel로 바꾸는 서비스
     """
-    assign_id = cancel_call_data.get('assign_id')
-    get_assign_info = Assign.objects.get(id=assign_id)
-    get_assign_info.status = 'cancel'
-    get_assign_info.save(update_fields=['status'])
+    try:
+        assign_id = cancel_call_data.get('assign_id')
+        get_assign_info = Assign.objects.get(id=assign_id)
+        get_assign_info.status = 'cancel'
+        get_assign_info.save(update_fields=['status'])
+    except Assign.DoesNotExist:
+        raise exceptions.NotFound("해당 데이터를 찾을 수 없습니다.")
     

--- a/call/services/call_main_service.py
+++ b/call/services/call_main_service.py
@@ -3,15 +3,19 @@ from utils.url_hashing import Hashing
 from call.serializers import CallMainGetSerializer, CallMainPostSerializer
 from django.utils import timezone
 from call.tasks import assign_driver_to_request
+from rest_framework import exceptions
 
 def get_main(hashed_qr_id: str):
     """"
     메인 화면 호출시 주소를 반환하는 서비스
     """
-    qr_id = Hashing.decode(hashed_qr_id)
-    get_qr_info = Qr.objects.get(id=qr_id)
-    get_qr_info_serializer = CallMainGetSerializer(get_qr_info).data
-    return get_qr_info_serializer
+    try:
+        qr_id = Hashing.decode(hashed_qr_id)
+        get_qr_info = Qr.objects.get(id=qr_id)
+        get_qr_info_serializer = CallMainGetSerializer(get_qr_info).data
+        return get_qr_info_serializer
+    except Qr.DoesNotExist:
+        raise exceptions.NotFound("해당 QR데이터를 찾을 수 없습니다.")
 
 def post_main(post_main_data, hashed_qr_id: str):
     """"

--- a/call/services/call_success_service.py
+++ b/call/services/call_success_service.py
@@ -6,19 +6,22 @@ from rest_framework import exceptions
 from redis import Redis
 from utils import Hashing
 from decouple import config
+from utils.redis_utils import get_redis_connection
 
 def get_driver_location(driver_id):
     """
     거리 시간계산을 위해 redis에 저장되어있는 기사의 위치를 불러오는 로직
     """
-    redis_host = config('REDIS_CACHE_HOST')
-    redis_port = config('REDIS_CACHE_PORT')
-
-    redis_con = Redis(host=redis_host, port=redis_port)
-    saved_location = redis_con.geopos("driver_location", driver_id)
-    result = (saved_location[0][0], saved_location[0][1])
-    return result
-
+    redis_con = get_redis_connection()
+    if redis_con == None:
+        raise exceptions.ValidationError("레디스 연결에 실패하였습니다.")
+    try:
+        saved_location = redis_con.geopos("driver_location", driver_id)
+        result = (saved_location[0][0], saved_location[0][1])
+        return result
+    except:
+        raise exceptions.NotFound("기사 위치 데이터를 찾을 수 없습니다.")
+    
 def change_ms_to_m(milliseconds):
     """
     밀리세컨즈로 나오는 duration 값을 ~분 ~초로 바꿔주는 로직
@@ -51,7 +54,7 @@ def calculate_estimated_distance(assign_info):
         try:
             result = response_body_json['route']['trafast'][0]['summary']
         except:
-            raise exceptions.ValidationError("좌표의 값이 잘못되었습니다.")
+            raise exceptions.ValidationError("좌표의 값이 잘못되어 시간 계산을 실패하였습니다.")
         
         duration = change_ms_to_m(result['duration'])
         return duration 
@@ -62,12 +65,15 @@ def get_success_info(hashed_assign_id: str):
     """
     기사가 배정된 assign 정보를 불러오는 service
     """
-    assign_id = Hashing.decode(hashed_assign_id)
-    get_assign_info = Assign.objects.select_related('qr_id', 'driver_id').get(id=assign_id)
-    if get_assign_info.status == 'success':
-        get_assign_serializer = CallSuccessGetSerializer(get_assign_info)
-        result = get_assign_serializer.data
-        result['estimated_time'] = calculate_estimated_distance(get_assign_info)
-        return result
-    else:
-        raise exceptions.ValidationError("잘못된 운행 상태입니다.")
+    try:
+        assign_id = Hashing.decode(hashed_assign_id)
+        get_assign_info = Assign.objects.select_related('qr_id', 'driver_id').get(id=assign_id)
+        if get_assign_info.status == 'success':
+            get_assign_serializer = CallSuccessGetSerializer(get_assign_info)
+            result = get_assign_serializer.data
+            result['estimated_time'] = calculate_estimated_distance(get_assign_info)
+            return result
+        else:
+            raise exceptions.ValidationError("잘못된 운행 상태입니다.")
+    except Assign.DoesNotExist:
+        raise exceptions.NotFound("해당 콜 데이터를 찾을 수 없습니다.")


### PR DESCRIPTION
### 작업한 내용
- 아무래도 call success 부분이 중요해서 예외처리를 더욱 강화시켜보았습니다.
- validation 예외는 view단을 통해서 에러 내용만 전달하도록 하였습니다.
- 404 not found 부분은 레이어 분리 원칙에는 조금 위배되지만 좋은 방법이 없어 서비스단에서 404에러를 일으키게 하였습니다.
- 이상한 점이 있으면 말씀해주세요!
## Exceptions

- 없는 Assign id를 입력했을 때

`HTTP 404 Not Found`

```json
{
    "detail": "해당 콜 데이터를 찾을 수 없습니다."
}
```

- 레디스 연결이 되어있지 않을 때

`HTTP 400 Bad Request`

```json
{
    "detail": "잘못된 요청입니다.",
    "error": [
        "레디스 연결에 실패하였습니다."
    ]
}
```

- 기사 위치를 알 수 없을 때

`HTTP 404 Not Found`

```json
{
    "detail": "기사 위치 데이터를 찾을 수 없습니다."
}
```

- 기사 위치가 이상하여 시간계산을 할 수 없을 때

`HTTP 400 Bad Request`

```json
{
    "detail": "잘못된 요청입니다.",
    "error": [
        "좌표의 값이 잘못되어 시간 계산을 실패하였습니다."
    ]
}
```

- 잘못된 운행 상태일 때(탑승 완료가 아니고 실패라던지)

`HTTP 400 Bad Request`

```json
{
    "detail": "잘못된 요청입니다.",
    "error": [
        "잘못된 운행 상태입니다."
    ]
}
```

### 추후 진행할 내용
- 구글 조사 만들기