### PR TITLE
feat: 상태 조회를 위한 api 작성

### DIFF
--- a/call/services/__init__.py
+++ b/call/services/__init__.py
@@ -5,3 +5,4 @@ from .receive_status_service import *
 from .call_riding_service import *
 from .call_finish_service import *
 from .receive_main_service import *
+from .call_request_status_service import *

--- a/call/services/call_request_status_service.py
+++ b/call/services/call_request_status_service.py
@@ -1,0 +1,14 @@
+from call.models import Assign
+from rest_framework import exceptions
+
+def response_status(request_status_data):
+    """
+    특정 assign의 status를 반환하는 서비스
+    """
+    try:
+        assign_id = request_status_data.get('assign_id')
+        get_assign_info = Assign.objects.get(id=assign_id)
+        response = {"status": get_assign_info.status}
+        return response
+    except Assign.DoesNotExist:
+        raise exceptions.NotFound("해당 assign을 찾을 수 없습니다.")

--- a/call/urls.py
+++ b/call/urls.py
@@ -1,5 +1,5 @@
 from django.urls import path
-from call.views import CallMainView, CallSuccessView, CallCancelView, ReceiveStatusView, ReceiveMainView, CallRidingView, CallFinishView
+from call.views import CallMainView, CallSuccessView, CallCancelView, ReceiveStatusView, ReceiveMainView, CallRidingView, CallFinishView, CallRequestStatusView
 from test.views import liveblog_index
 app_name = 'call'
 
@@ -7,9 +7,11 @@ urlpatterns = [
     path("wstest/<str:post_pk>/", liveblog_index),
     path('main/<str:hashed_qr_id>', CallMainView.as_view()),
     path('cancel/', CallCancelView.as_view()),
+    path('status/', CallRequestStatusView.as_view()),
     path('success/<str:hashed_assign_id>', CallSuccessView.as_view()),
     path('receive/', ReceiveStatusView.as_view()),
     path('<int:assign_id>/', ReceiveMainView.as_view()),
     path('<int:assign_id>/riding/', CallRidingView.as_view()),
     path('<int:assign_id>/finish/', CallFinishView.as_view()),
 ]
+

--- a/call/views/__init__.py
+++ b/call/views/__init__.py
@@ -5,3 +5,4 @@ from .receive_status_view import ReceiveStatusView
 from .call_riding_view import CallRidingView
 from .call_finish_view import CallFinishView
 from .receive_main_view import ReceiveMainView
+from .call_request_status_view import CallRequestStatusView

--- a/call/views/call_request_status_view.py
+++ b/call/views/call_request_status_view.py
@@ -1,0 +1,16 @@
+from rest_framework.response import Response
+from rest_framework import status, exceptions
+from rest_framework.views import APIView
+from call.services import response_status
+
+
+class CallRequestStatusView(APIView):
+    """
+    소켓이 끊겼을 때, 해당 assign의 status를 조회하여 response 보내주는 view
+    """
+    def post(self, request):
+        try:
+            response = response_status(request.data)
+            return Response(response, status=status.HTTP_201_CREATED)
+        except exceptions.ValidationError as e:
+             return Response({"detail": "잘못된 요청입니다.", "error": e.detail}, status=status.HTTP_400_BAD_REQUEST)


### PR DESCRIPTION
### 작업한 내용
- 특정 assign의 status를 조회하기 위한 api를 작성했습니다.
- 언제 필요하냐면 모바일 화면이 꺼지거나 했을 때 소켓은 끊기게 됩니다.
- 이 때, 소켓이 끊겼을 때, 서버에서 해당 assign의 상태가 변하게 되면 model signal을 받지 못하기 때문에 실제로 서버에서 `배정완료`가 되었어도 여전히 `배정중` 페이지를 보여주게 됩니다.
- 그래서 소켓을 재연결했을 때, 프론트엔드에서 이 api를 통해서 assign의 status를 조회하게 되면 현재 assign의 status에 따라서 화면을 즉시 업데이트 해줄 수 있습니다. 