### PR TITLE
refactor: model signal 확장을 위한 django channel 관련 코드 리팩토링

### DIFF
--- a/call/consumers/call_consumers.py
+++ b/call/consumers/call_consumers.py
@@ -43,5 +43,5 @@ class CallConsumer(JsonWebsocketConsumer):
     def cancel(self, event_dict):
         self.send_json(event_dict)
 
-    def deleted(self, event_dict):
+    def error(self, event_dict):
         self.send_json(event_dict)


### PR DESCRIPTION
### 작업한 내용
- 모델 시그널에 웹 푸시 메시지 기능을 추가하기 위해서 기존의 Django channels 관련 코드를 분리시켰습니다.
- 또한 `delete` 시그널을 없애고 `error` 시그널을 추가했습니다.

### 추후 진행할 내용
- 웹 푸시 알람 기능 추가