### PR TITLE
refactor: 기사 콜 요청에 대한 예외처리

### DIFF
--- a/call/services/call_success_service.py
+++ b/call/services/call_success_service.py
@@ -12,7 +12,7 @@ def get_driver_location(driver_id):
     """
     거리 시간계산을 위해 redis에 저장되어있는 기사의 위치를 불러오는 로직
     """
-    redis_con = get_redis_connection()
+    redis_con = get_redis_connection(db_select=0)
     if redis_con == None:
         raise exceptions.ValidationError("레디스 연결에 실패하였습니다.")
     try:

--- a/call/services/receive_status_service.py
+++ b/call/services/receive_status_service.py
@@ -29,7 +29,7 @@ def get_accept_status(data, driver):
         return {'statusCode': 404, 'message': "해당 배정정보가 없습니다."}
 
     if not validate_driver(assign_id, driver.id):
-        return {'statusCode': 400, 'message': "현재 처리 중인 기사가 아닙니다."}
+        return {'statusCode': 400, 'message': "현재 콜 요청을 받은 기사님이 아닙니다."}
 
     if accepted:
         if get_assign_info.status == "cancel":

--- a/call/services/receive_status_service.py
+++ b/call/services/receive_status_service.py
@@ -37,7 +37,7 @@ def get_accept_status(data, driver):
         try:
             get_driver_info = CustomDriver.objects.get(id=driver.id)
         except CustomDriver.DoesNotExist:
-            return {'statusCode': 404, 'message': "해당 가사님이 존재하지 않습니다."}
+            return {'statusCode': 404, 'message': "해당 기사님이 존재하지 않습니다."}
         get_assign_info.status = 'success'
         get_assign_info.driver_id = driver
         get_driver_info.is_able = False

--- a/call/services/receive_status_service.py
+++ b/call/services/receive_status_service.py
@@ -1,5 +1,21 @@
 from call.models import Assign
 from driver.models import CustomDriver
+from utils.redis_utils import get_redis_connection
+
+def validate_driver(assign_id, driver_id):
+    """
+    현재 수락 요청을 보낸 기사 id와 콜요청 메시지 받은 기사와 일치하는지 확인
+    """
+    key = f'assign_{assign_id}'
+    redis_conn = get_redis_connection()
+    current_driver_id = redis_conn.lindex(key, 0)
+
+    if current_driver_id is None:
+        return False
+
+    current_driver_id = int(current_driver_id)
+    return current_driver_id == driver_id
+
 
 def get_accept_status(data, driver):
     """
@@ -7,10 +23,21 @@ def get_accept_status(data, driver):
     """
     assign_id = data.get('assign_id')
     accepted = data.get('accepted')
+    try:
+        get_assign_info = Assign.objects.get(id=assign_id)
+    except Assign.DoesNotExist:
+        return {'statusCode': 404, 'message': "해당 배정정보가 없습니다."}
+
+    if not validate_driver(assign_id, driver.id):
+        return {'statusCode': 400, 'message': "현재 처리 중인 기사가 아닙니다."}
 
     if accepted:
-        get_assign_info = Assign.objects.get(id=assign_id)
-        get_driver_info = CustomDriver.objects.get(id=driver.id)
+        if get_assign_info.status == "cancel":
+            return {'statusCode': 400, 'message': "이미 취소된 배정입니다."}
+        try:
+            get_driver_info = CustomDriver.objects.get(id=driver.id)
+        except CustomDriver.DoesNotExist:
+            return {'statusCode': 404, 'message': "해당 가사님이 존재하지 않습니다."}
         get_assign_info.status = 'success'
         get_assign_info.driver_id = driver
         get_driver_info.is_able = False

--- a/call/services/receive_status_service.py
+++ b/call/services/receive_status_service.py
@@ -7,7 +7,7 @@ def validate_driver(assign_id, driver_id):
     현재 수락 요청을 보낸 기사 id와 콜요청 메시지 받은 기사와 일치하는지 확인
     """
     key = f'assign_{assign_id}'
-    redis_conn = get_redis_connection()
+    redis_conn = get_redis_connection(db_select=1)
     current_driver_id = redis_conn.lindex(key, 0)
 
     if current_driver_id is None:

--- a/call/tasks.py
+++ b/call/tasks.py
@@ -30,7 +30,7 @@ def assign_driver_to_request(assign_id, qr_id):
     가까운 기사 10분에게 차례대로 메시지를 보내는 로직
     """
     channel_layer = get_channel_layer()
-    redis_conn = get_redis_connection()
+    redis_conn = get_redis_connection(db_select=1)
 
     qr = Qr.objects.get(id=qr_id)
     user_longitude = qr.longitude

--- a/call/tasks.py
+++ b/call/tasks.py
@@ -7,6 +7,7 @@ from channels.layers import get_channel_layer
 from driver.models import CustomDriver
 from driver.services import get_nearest_drivers
 from qr.models import Qr
+from utils.redis_utils import get_redis_connection
 
 def check_response(assign_id, driver_id):
     """
@@ -29,16 +30,25 @@ def assign_driver_to_request(assign_id, qr_id):
     가까운 기사 10분에게 차례대로 메시지를 보내는 로직
     """
     channel_layer = get_channel_layer()
+    redis_conn = get_redis_connection()
 
     qr = Qr.objects.get(id=qr_id)
     user_longitude = qr.longitude
     user_latitude = qr.latitude
     driver_id_list = get_nearest_drivers(user_latitude, user_longitude)
 
+    key = f'assign_{assign_id}'
+    redis_conn.delete(key)
+    redis_conn.rpush(key, *driver_id_list)
+    redis_conn.expire(key, 3600)
 
     for driver_id in driver_id_list:
+        if int(redis_conn.lindex(key, 0)) != driver_id:
+            continue
+
         driver = CustomDriver.objects.get(id=driver_id)
         if not driver.is_able:
+            redis_conn.lpop(key)
             continue
 
         async_to_sync(channel_layer.group_send)(
@@ -59,6 +69,7 @@ def assign_driver_to_request(assign_id, qr_id):
             elif result:
                 return "Accepted"
             time.sleep(1)
+        redis_conn.lpop(key)
 
     Assign.objects.filter(id=assign_id).update(status='failed')
 

--- a/call/views/receive_status_view.py
+++ b/call/views/receive_status_view.py
@@ -15,6 +15,11 @@ class ReceiveStatusView(APIView):
     def post(self, request):
         try:
             response = get_accept_status(request.data, request.user)
-            return Response(response, status=status.HTTP_200_OK)
+            if response["statusCode"] == 200:
+                return Response(response, status=status.HTTP_200_OK)
+            elif response["statusCode"] == 400:
+                return Response(response, status=status.HTTP_400_BAD_REQUEST)
+            elif response["statusCode"] == 404:
+                return Response(response, status=status.HTTP_404_NOT_FOUND)
         except exceptions.ValidationError:
             return Response({"statusCode": 400, "detail": "잘못된 요청입니다."}, status=status.HTTP_400_BAD_REQUEST)

--- a/driver/services/driver_location_service.py
+++ b/driver/services/driver_location_service.py
@@ -7,7 +7,7 @@ def get_driver_location(data):
     driver_id = data.get('driver_id')
     longitude = data.get('longitude')
     latitude = data.get('latitude')
-    redis_conn = get_redis_connection()
+    redis_conn = get_redis_connection(db_select=0)
 
     if not (-90 <= float(latitude) <= 90) or not (-180 <= float(longitude) <= 180) or not all([driver_id, latitude, longitude]):
         return {'statusCode': 400, 'message': '잘못된 입력값이 있습니다. 모든 필드를 제대로 채웠는지 확인해주세요.'}
@@ -24,7 +24,7 @@ def get_nearest_drivers(latitude, longitude):
     """
     반경 1km 내에 있는 기사 중 가까운 순으로 10명의 기사 추출하는 Service
     """
-    redis_conn = get_redis_connection()
+    redis_conn = get_redis_connection(db_select=0)
 
     if not (-90 <= float(latitude) <= 90) or not (-180 <= float(longitude) <= 180) or not all([latitude, longitude]):
         return {'statusCode': 400, 'message': '잘못된 입력값이 있습니다. 모든 필드를 제대로 채웠는지 확인해주세요.'}

--- a/utils/redis_utils.py
+++ b/utils/redis_utils.py
@@ -1,10 +1,10 @@
 from decouple import config
 from redis import Redis
 
-def get_redis_connection():
+def get_redis_connection(db_select: int):
     redis_host = config('REDIS_CACHE_HOST')
     redis_port = config('REDIS_CACHE_PORT')
-    redis_con = Redis(host=redis_host, port=redis_port)
+    redis_con = Redis(host=redis_host, port=redis_port, db= db_select)
 
     try:
         if not redis_con.ping():


### PR DESCRIPTION
### 작업한 내용
- 기사 콜 요청에 대한 예외처리 진행
  1. 해당 배정이 없을 때 + 해당 기사가 없을 때 -> 404 반환
  2. 이미 취소된 배정일 때 -> 400반환
  3. 현재 수락 요청을 보낸 기사 id와 콜요청 메시지 받은 기사가 일치하지 않을 때 -> 400 반환

### 3번에 대한 부연 설명
- 수락 요청을 보낸 기사 id가 콜요청을 받은 기사 id와 일치하지 않을 때(효원이가 말한 부분) 400 에러를 반환하기 위해 레디스를 이용했습니다.

**tasks.py**
- ` redis_conn.rpush(key, *driver_id_list)`
  - 가까운 기사 10명을 뽑아왔을 때 해당 assign_id를 키로 설정하고 레디스 리스트에 저장합니다.
- ` redis_conn.expire(key, 3600)`
  - 이때 해당 데이터를 오래 가지고 있을 필요가 없기 때문에 만료 시간을 설정했습니다.
- `redis_conn.lpop(key)`
   - 만약에 해당 드라이버가 운행이 불가능한 상태일 경우 + 5초 내로 수락을 하지 않은 경우 -> 가장 첫번째 인덱스에 있는 기사 id를 pop합니다.

**receive_status_service.py**
- 기사가 수락 요청을 보낼 때, `current_driver_id = redis_conn.lindex(key, 0)` 현재 콜요청을 받고 있는 기사님인지(즉 첫번째 인덱스 기사님) 확인을 하고 일치하지 않는다면 400 에러를 반환하게 됩니다.


### 논의할 내용
- 수락 요청을 보낸 기사 id가 콜요청을 받은 기사 id와 일치하지 않을 때를 어떻게 할까 고민했는데 assign 테이블에 매번 현재 콜요청을 받은 기사님 id를 저장해서 비교하는 방법이 번거로울거 같아 레디스를 이용했습니다. 
- 현재 로컬에서 가능한 상황들을 모두 테스트해보았고 잘 작동하는 것까지 확인했습니다. 혹시 코드에 대해 논의사항이 있으면 말씀해주세요..!

