### PR TITLE
fix: status failed 지정 방식 변경

### DIFF
--- a/call/tasks.py
+++ b/call/tasks.py
@@ -71,6 +71,8 @@ def assign_driver_to_request(assign_id, qr_id):
             time.sleep(1)
         redis_conn.lpop(key)
 
-    Assign.objects.filter(id=assign_id).update(status='failed')
+    get_assign_info = Assign.objects.get(id=assign_id)
+    get_assign_info.status = 'failed'
+    get_assign_info.save(update_fields=['status'])
 
     return "Not accepted"


### PR DESCRIPTION
### 작업한 내용
- 현재 실험한 결과, 배정실패로 바뀌어도 웹에서 배정실패 페이지가 넘어가지 않는 상황이 발생했습니다.
- 자세히 살펴본 결과 failed로 바뀌어도 socket 메세지가 오지 않고 있었습니다.
```python
Assign.objects.filter(id=assign_id).update(status='failed')
```
- 그래서 살펴보니 위의 기존 코드는 `update` 방식으로, 데이터베이스 차원에서 값을 수정하기 때문에 `save()`가 호출되지 않는다고 합니다.
- 따라서 `save()`가 호출되기 위해서 코드를 수정하였습니다.

### 논의할 내용
- 가까운 위치에서 두번 호출하는 경우
- 콜 수락이 가능한 기사가 1명일 경우, 5초 후에 바로 배정실패가 되어서, 호출 실패로 되버립니다.. 몇 분 잡아두고 계속 `get_nearest_drivers` 함수를 불러오게 만들면 어떨까요?? 로직은 저도 생각해보겠습니다.