### PR TITLE
feat: message에 status data 추가

### DIFF
--- a/call/models/assign_signals.py
+++ b/call/models/assign_signals.py
@@ -50,6 +50,9 @@ def send_push_notification(instance):
             title='큐택 택시 정보 알림',
             body=body
         ),
+        data = {
+            'status': instance.status
+        },
         token=registration_token,
     )
     response = messaging.send(message)


### PR DESCRIPTION
### 작업한 내용
- 디바이스에서 푸시 메세지를 클릭하면 해당 url로 이동해야 된다고 하길래 status data를 추가하였습니다. 동작 할지는 아직 토큰을 받아보지 않아서 모릅니다,,
``` json
{
    "notification": {
        "title": "큐택 택시 정보 알림",
        "body": "[본문 메시지]",
        ... // 기타 FCM notification 필드
    },
    "data": {
        "status": "[상태값]"
    },
    ... // 기타 FCM 메시지 필드
}

```