### PR TITLE
fix: Created 모델 시그널일 때 send_push_notification 무시 추가

### DIFF
--- a/call/models/assign.py
+++ b/call/models/assign.py
@@ -31,7 +31,8 @@ class Assign(ChannelLayerGroupSendMixin, models.Model):
     
 def call__on_post_save(instance: Assign, created: bool, **kwargs):
     websocket_message(instance, created)
-    send_push_notification(instance)
+    if not created:
+        send_push_notification(instance)
 
 post_save.connect(
     call__on_post_save,


### PR DESCRIPTION
### 작업한 내용
- 현재 모델 시그널이 created 일 때도 send_push_notification를 불러오기 때문에 핸드폰 번호를 기입하는 시점에서도 send_push_notification가 불러와져서 404   `"detail": "토큰이 존재하지 않습니다."` 에러가 뜨는 것 같습니다. 그래서 if 문을 추가했습니다!