### PR TITLE
fix: failed 푸시 알람을 위한 celery firebase 초기화

### DIFF
--- a/call/models/assign_signals.py
+++ b/call/models/assign_signals.py
@@ -1,4 +1,5 @@
 from firebase_admin import messaging
+import firebase_admin
 
 def websocket_message(instance, created: bool):
     from . import Assign
@@ -55,5 +56,10 @@ def send_push_notification(instance):
         },
         token=registration_token,
     )
-    response = messaging.send(message)
+    if instance.status == "failed":
+        app = firebase_admin.get_app('celery_app')
+    else:
+        app = firebase_admin.get_app('asgi_app')
+    
+    response = messaging.send(message, app=app)
     print('Successfully sent message:', response)

--- a/hackathon/asgi.py
+++ b/hackathon/asgi.py
@@ -18,7 +18,8 @@ os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'hackathon.settings')
 
 cred_path = config("FIRE_BASE_JSON_KEY_PATH")
 cred = credentials.Certificate(cred_path)
-firebase_admin.initialize_app(cred)
+if not firebase_admin._apps:
+    firebase_admin.initialize_app(cred)
 
 django_asgi_app = get_asgi_application()
 

--- a/hackathon/asgi.py
+++ b/hackathon/asgi.py
@@ -18,8 +18,7 @@ os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'hackathon.settings')
 
 cred_path = config("FIRE_BASE_JSON_KEY_PATH")
 cred = credentials.Certificate(cred_path)
-if not firebase_admin._apps:
-    firebase_admin.initialize_app(cred)
+firebase_admin.initialize_app(cred, name='asgi_app')
 
 django_asgi_app = get_asgi_application()
 

--- a/hackathon/celery.py
+++ b/hackathon/celery.py
@@ -13,8 +13,7 @@ app.autodiscover_tasks()
 
 cred_path = config("FIRE_BASE_JSON_KEY_PATH")
 cred = credentials.Certificate(cred_path)
-if not firebase_admin._apps:
-    firebase_admin.initialize_app(cred)
+firebase_admin.initialize_app(cred, name='celery_app')
 
 #테스트할 때만 주석해제하고 실제로 배포할 때는 주석처리하기
 #@app.task(bind=True, ignore_result=True)

--- a/hackathon/celery.py
+++ b/hackathon/celery.py
@@ -1,5 +1,8 @@
 import os
 from celery import Celery
+import firebase_admin
+from firebase_admin import credentials
+from decouple import config
 
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'hackathon.settings.prod')
 
@@ -7,6 +10,11 @@ app = Celery('hackathon')
 app.config_from_object('django.conf:settings', namespace='CELERY')
 
 app.autodiscover_tasks()
+
+cred_path = config("FIRE_BASE_JSON_KEY_PATH")
+cred = credentials.Certificate(cred_path)
+if not firebase_admin._apps:
+    firebase_admin.initialize_app(cred)
 
 #테스트할 때만 주석해제하고 실제로 배포할 때는 주석처리하기
 #@app.task(bind=True, ignore_result=True)


### PR DESCRIPTION
### 작업한 내용
- 예외처리를 하고보니 이러한 에러가 발생하고 있었습니다. 최초에 `failed` 푸시 알람 시그널을 받으면
```linux
[2023-08-17 12:26:04,838: WARNING/ForkPoolWorker-1] 푸시 알람 실패
[2023-08-17 12:26:04,839: WARNING/ForkPoolWorker-1]  
[2023-08-17 12:26:04,839: WARNING/ForkPoolWorker-1] The default Firebase app does not exist. Make sure to initialize the SDK by calling initialize_app().
```
- 이렇게 firebase 앱이 초기화 되지 않았다고 나옵니다.
- 왜 그런지 봤더니 `failed` status는 기존 asgi.py에서 실행되는 `daphne` 서버(장고 메인 서버)에서 설정되는 것이 아니라 celery에서 관리되는 task.py 에서 바뀌는 것이었습니다.
- 기존 asgi.py에서는 FireBase가 초기화 되었지만 celery는 독립적인 프로세스라서 celery내에서도 FireBase를 초기화시켜 줘야하는 소요가 발생했습니다.
- 그런데 만약 daphne 서버 FIrebase가 실행되고 있으면 이런 에러가 발생합니다.
```
ValueError: The default Firebase app already exists. This means you called initialize_app() more than once without providing an app name as the second argument. In most cases you only need to call initialize_app() once. But if you do want to initialize multiple apps, pass a second argument to initialize_app() to give each app a unique name.
```
- 각각 `celery_app`, `asgi_app`으로 초기화를 시켜서 failed signal이면 `celery_app`, 나머지는 `asgi_app` 이름의 firebase app으로 메세지를 보내게 바꾸었습니다.
